### PR TITLE
improved logging

### DIFF
--- a/cron/alerts/main.go
+++ b/cron/alerts/main.go
@@ -141,6 +141,7 @@ func sendAnEmail(emailMsg sesTypes.Message, sender, recipient string) error {
 	if err != nil {
 		return fmt.Errorf("send email failed: %w", err)
 	}
+	log.Printf("sent %q email to %q", *emailMsg.Subject.Data, recipient)
 	return nil
 }
 

--- a/cron/alerts/main.go
+++ b/cron/alerts/main.go
@@ -173,7 +173,7 @@ func (a *Alert) sendEmails(cfRecords map[string][]string) {
 	}
 
 	if lastError != "" {
-		a.logLastError(lastError, badRecipients)
+		a.logEmailError(lastError, badRecipients)
 	}
 }
 
@@ -198,7 +198,7 @@ func (a *Alert) sendErrorEmails(err error) {
 	}
 
 	if lastError != "" {
-		a.logLastError(lastError, badRecipients)
+		a.logEmailError(lastError, badRecipients)
 	}
 }
 
@@ -229,12 +229,12 @@ func makeSESMessage(charSet, subject, msg string) sesTypes.Message {
 	return emailMsg
 }
 
-func (a *Alert) logLastError(lastError string, badRecipients []string) {
+func (a *Alert) logEmailError(errorMessage string, badRecipients []string) {
 	addresses := strings.Join(badRecipients, ", ")
 	log.Printf("Error sending Cloudflare scanner email from %q to %q: %s",
 		*aws.String(a.SESReturnToAddr),
 		addresses,
-		lastError,
+		errorMessage,
 	)
 }
 

--- a/cron/alerts/main.go
+++ b/cron/alerts/main.go
@@ -89,7 +89,7 @@ func (a *Alert) getCFRecords() map[string][]string {
 		log.Fatal(err)
 	}
 
-	log.Printf("Starting scan for %v", a.CFZoneNames)
+	log.Printf("scanning zones: %s", strings.Join(a.CFZoneNames, ", "))
 
 	results := map[string][]string{}
 
@@ -137,11 +137,10 @@ func sendAnEmail(emailMsg sesTypes.Message, sender, recipient string) error {
 		return err
 	}
 	svc := ses.NewFromConfig(cfg)
-	result, err := svc.SendEmail(context.Background(), input)
+	_, err = svc.SendEmail(context.Background(), input)
 	if err != nil {
 		return fmt.Errorf("send email failed: %w", err)
 	}
-	log.Println(result)
 	return nil
 }
 
@@ -166,12 +165,15 @@ func (a *Alert) sendEmails(cfRecords map[string][]string) {
 	for _, address := range a.RecipientEmails {
 		err := sendAnEmail(emailMsg, address, a.SESReturnToAddr)
 		if err != nil {
+			log.Printf("error sending alert email %s: %s", msg, err)
 			lastError = err.Error()
 			badRecipients = append(badRecipients, address)
 		}
 	}
 
-	a.logLastError(lastError, badRecipients)
+	if lastError != "" {
+		a.logLastError(lastError, badRecipients)
+	}
 }
 
 func (a *Alert) sendErrorEmails(err error) {
@@ -188,12 +190,15 @@ func (a *Alert) sendErrorEmails(err error) {
 	for _, address := range a.RecipientEmails {
 		err := sendAnEmail(emailMsg, address, a.SESReturnToAddr)
 		if err != nil {
+			log.Printf("error sending error email %s: %s", msg, err)
 			lastError = err.Error()
 			badRecipients = append(badRecipients, address)
 		}
 	}
 
-	a.logLastError(lastError, badRecipients)
+	if lastError != "" {
+		a.logLastError(lastError, badRecipients)
+	}
 }
 
 func makeSESMessage(charSet, subject, msg string) sesTypes.Message {
@@ -224,10 +229,6 @@ func makeSESMessage(charSet, subject, msg string) sesTypes.Message {
 }
 
 func (a *Alert) logLastError(lastError string, badRecipients []string) {
-	if lastError == "" {
-		return
-	}
-
 	addresses := strings.Join(badRecipients, ", ")
 	log.Printf("Error sending Cloudflare scanner email from %q to %q: %s",
 		*aws.String(a.SESReturnToAddr),

--- a/cron/alerts/main_test.go
+++ b/cron/alerts/main_test.go
@@ -23,3 +23,10 @@ func TestGetCFRecords(t *testing.T) {
 		}
 	}
 }
+
+func TestHandler(t *testing.T) {
+	err := handler()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}

--- a/cron/alerts/main_test.go
+++ b/cron/alerts/main_test.go
@@ -25,6 +25,8 @@ func TestGetCFRecords(t *testing.T) {
 }
 
 func TestHandler(t *testing.T) {
+	t.Skip("Only run this in local development")
+
 	err := handler()
 	if err != nil {
 		t.Errorf("%s", err)

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,6 +61,6 @@ functions:
     events:
       # cron(Minutes Hours Day-of-month Month Day-of-week Year)
       # Either `day-of-month` or `day-of-week` must be a question mark (?)
-       - schedule: cron(30 12,14,18,20 ? * MON,TUE,WED,THU,FRI *)
+       - schedule: cron(30 0/2 ? * MON,TUE,WED,THU,FRI *)
     tags:
       name: lambda_function_1-${self:custom.app_name}-${self:custom.customer}-production

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,6 +61,6 @@ functions:
     events:
       # cron(Minutes Hours Day-of-month Month Day-of-week Year)
       # Either `day-of-month` or `day-of-week` must be a question mark (?)
-       - schedule: cron(30 0/2 ? * MON,TUE,WED,THU,FRI *)
+       - schedule: cron(30 0/2 ? * * *)
     tags:
       name: lambda_function_1-${self:custom.app_name}-${self:custom.customer}-production


### PR DESCRIPTION
### Changed
- Run every two hours around the clock, not just during Eastern time office hours

### Fixed
- Log an error for each failed send
- Log a success message after sending
- Clarify the log message that lists the zones being scanned
- Don't log the email result; it contains no useful data