### PR TITLE
SAM "take 2"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
     needs: test
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
     - uses: aws-actions/setup-sam@v2
+      with:
+        use-installer: true
+        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     if: github.ref_name == 'main'
+    needs: test
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/template.yaml
+++ b/template.yaml
@@ -50,6 +50,11 @@ Resources:
           - appconfig:StartConfigurationSession
           Resource:
           - !Sub arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/${AppId}/environment/${EnvId}/configuration/${ConfigId}
+  CloudflareScanLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AlertFunction}"
+      RetentionInDays: 60
 
 Parameters:
   AppId:

--- a/template.yaml
+++ b/template.yaml
@@ -65,4 +65,4 @@ Parameters:
 Outputs:
   CloudflareScanFunctionArn:
     Description: ARN of the Cloudflare Scan function
-    Value: !GetAtt CloudflareScannerFunction.Arn
+    Value: !GetAtt AlertFunction.Arn

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,5 +6,146 @@ module "serverless-user" {
   source  = "silinternational/serverless-user/aws"
   version = "~> 0.4.2"
 
-  app_name   = "cloudflare-scanner"
+  app_name = var.app_name
+
+  policy_override = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "cloudformation:List*",
+          "cloudformation:Get*",
+          "cloudformation:ValidateTemplate",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+      {
+        Action = [
+          "cloudformation:CreateStack",
+          "cloudformation:CreateUploadBucket",
+          "cloudformation:DeleteStack",
+          "cloudformation:Describe*",
+          "cloudformation:UpdateStack",
+          "cloudformation:DescribeChangeSet",
+          "cloudformation:DeleteChangeSet",
+          "cloudformation:CreateChangeSet",
+          "cloudformation:ExecuteChangeSet",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:cloudformation:${var.aws_region}:*:stack/${var.app_name}",
+          "arn:aws:cloudformation:${var.aws_region}:*:stack/aws-sam-cli-managed-default/*",
+          "arn:aws:cloudformation:${var.aws_region}:aws:transform/Serverless-2016-10-31",
+        ]
+      },
+      {
+        Action = [
+          "events:Put*",
+          "events:Remove*",
+          "events:Delete*",
+          "events:DescribeRule"
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:events:${var.aws_region}::event-source/*",
+          "arn:aws:events:${var.aws_region}:*:rule/${var.app_name}*",
+          "arn:aws:events:${var.aws_region}:*:event-bus/*",
+        ]
+      },
+      {
+        Action = [
+          "lambda:Get*",
+          "lambda:List*",
+          "lambda:CreateFunction",
+        ],
+        Effect   = "Allow"
+        Resource = "*"
+      },
+      {
+        Action = [
+          "lambda:AddPermission",
+          "lambda:CreateAlias",
+          "lambda:DeleteFunction",
+          "lambda:InvokeFunction",
+          "lambda:PublishVersion",
+          "lambda:RemovePermission",
+          "lambda:TagResource",
+          "lambda:UntagResource",
+          "lambda:Update*",
+          "lambda:PutFunctionEventInvokeConfig",
+          "lambda:DeleteFunctionEventInvokeConfig",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:lambda:${var.aws_region}:*:function:${var.app_name}-alert",
+          "arn:aws:lambda:${var.aws_region}:*:event-source-mapping:*",
+        ]
+      },
+      {
+        Action = [
+          "iam:AttachRolePolicy",
+          "iam:GetRole",
+          "iam:CreateRole",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:DeleteRole",
+          "iam:PassRole",
+          "iam:TagRole",
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:iam::*:role/${var.app_name}-AlertFunctionRole-*"
+      },
+      {
+        Action = [
+          "logs:DeleteLogGroup"
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:logs:${var.aws_region}:*:log-group:/aws/lambda/${var.app_name}*"
+      },
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutRetentionPolicy",
+          "logs:ListTagsForResource",
+          "logs:TagResource",
+          "logs:UntagResource"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+      {
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:CreateBucket",
+          "s3:DeleteBucket",
+          "s3:ListBucket",
+          "s3:ListBucketVersions",
+          "s3:PutBucketAcl",
+          "s3:PutAccelerateConfiguration",
+          "s3:GetEncryptionConfiguration",
+          "s3:PutEncryptionConfiguration",
+          "s3:GetBucketPolicy",
+          "s3:PutBucketPolicy",
+          "s3:DeleteBucketPolicy",
+          "s3:PutBucketPublicAccessBlock",
+          "s3:PutBucketTagging"
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:s3:::${var.app_name}*"
+      },
+      {
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject"
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*/${var.app_name}/*"
+      }
+    ],
+  })
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
     }
   }
 }


### PR DESCRIPTION
### Changed
- Updated IAM user permissions for SAM
- Specify log retention rather than relying on Lambda to auto-create a log group with infinite retention
- Use the "use-installer" option as recommended by the setup-sam README. It may allow SAM output to be cached. We'll see.

### Fixed
- Fixed a broken reference in the template output
- Add "needs: test" to stop the workflow on a test failure